### PR TITLE
feat: 알람 api 로직 강사님 코드처럼 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'com.fasterxml.jackson.core:jackson-databind' // ✅ JSON 변환
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/pieceofcake/alert_service/alert/application/AlertService.java
+++ b/src/main/java/com/pieceofcake/alert_service/alert/application/AlertService.java
@@ -7,12 +7,6 @@ import com.pieceofcake.alert_service.kafka.event.AlertKafkaEvent;
 import reactor.core.publisher.Flux;
 
 public interface AlertService {
-    AlertResponseDto getAlert(AlertKafkaEvent alertKafkaEvent, AlertType alertType);
-
-    // SSE 연결을 위한 메소드 추가
-    Flux<AlertResponseVo> getAlertStream();
-
-    // 새로 추가할 메소드
-    Flux<AlertResponseVo> getMemberAlertStream(String memberUuid);
-    Flux<AlertResponseVo> getCommonAlertStream();
+    void getAlert(AlertKafkaEvent alertKafkaEvent, AlertType alertType);
+    Flux<AlertResponseDto> getAlertByMemberUuid(String memberUuid);
 }

--- a/src/main/java/com/pieceofcake/alert_service/alert/application/AlertServiceImpl.java
+++ b/src/main/java/com/pieceofcake/alert_service/alert/application/AlertServiceImpl.java
@@ -1,11 +1,21 @@
 package com.pieceofcake.alert_service.alert.application;
 
+import com.mongodb.client.model.changestream.OperationType;
 import com.pieceofcake.alert_service.alert.dto.out.AlertResponseDto;
+import com.pieceofcake.alert_service.alert.entity.Alert;
 import com.pieceofcake.alert_service.alert.entity.enums.AlertType;
+import com.pieceofcake.alert_service.alert.infrastructure.AlertMongoRepository;
 import com.pieceofcake.alert_service.alert.vo.out.AlertResponseVo;
 import com.pieceofcake.alert_service.kafka.event.AlertKafkaEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.ChangeStreamEvent;
+import org.springframework.data.mongodb.core.ChangeStreamOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
@@ -20,94 +30,79 @@ import java.util.concurrent.atomic.AtomicReference;
 @RequiredArgsConstructor
 public class AlertServiceImpl implements AlertService {
 
-//    private final Sinks.Many<AlertResponseDto> alertSink = Sinks.many().multicast().onBackpressureBuffer();
-    private final AtomicReference<Sinks.Many<AlertResponseDto>> sinkRef =
-        new AtomicReference<>(Sinks.many().replay().latest());
+    private final MongoTemplate mongoTemplate;
+    private final ReactiveMongoTemplate reactiveMongoTemplate;
+    private final AlertMongoRepository alertMongoRepository;
 
-    /**
-     * 현재 sink를 반환. TERMINATED 상태면 새로 만든 뒤 리턴
-     */
-    private Sinks.Many<AlertResponseDto> getOrCreateSink() {
-        Sinks.Many<AlertResponseDto> sink = sinkRef.get();
-        if (Boolean.TRUE.equals(sink.scan(Scannable.Attr.TERMINATED))) {
-            log.info("[SSE] 기존 sink가 TERMINATED 상태 감지, 새로운 sink 생성");
-            Sinks.Many<AlertResponseDto> fresh = Sinks.many().replay().latest();
-            sinkRef.set(fresh);
-            return fresh;
+    @Override
+    public void getAlert(AlertKafkaEvent alertKafkaEvent, AlertType alertType) {
+        log.info("@@@@@@@123");
+        mongoTemplate.save(alertKafkaEvent.toEntity(alertType));
+        log.info("@@@@@@@");
+    }
+
+    @Override
+    public Flux<AlertResponseDto> getAlertByMemberUuid(String memberUuid) {
+
+        ChangeStreamOptions options;
+
+        Flux<Alert> alertFlux;
+
+
+        if (memberUuid == null || memberUuid.isBlank()) {
+            options = ChangeStreamOptions.builder()
+                    .filter(Aggregation.newAggregation(
+                            Aggregation.match(Criteria.where("operationType").is(OperationType.INSERT.getValue())),
+                            Aggregation.match(Criteria.where("fullDocument.commonAlert").is(true))
+                    )).build();
+        } else {
+            options = ChangeStreamOptions.builder()
+                    .filter(Aggregation.newAggregation(
+                            Aggregation.match(Criteria.where("operationType").is(OperationType.INSERT.getValue())),
+                            Aggregation.match(
+                                    new Criteria().orOperator(
+                                            Criteria.where("fullDocument.commonAlert").is(true),
+                                            Criteria.where("fullDocument.commonAlert").is(false)
+                                                    .and("fullDocument.memberUuid").is(memberUuid)
+                                    )
+                            )
+                    )).build();
         }
-        return sink;
+
+        return reactiveMongoTemplate.changeStream("alert_message_entity", options, Document.class)
+                .map(ChangeStreamEvent::getBody)
+                .map(document -> AlertResponseDto.builder()
+                        .key(document.getString("key"))
+                        .message(document.getString("message"))
+                        .memberUuid(document.getString("memberUuid"))
+                        .alertType(AlertType.valueOf(document.getString("alertType")))
+                        .build());
+
+//        if (memberUuid == null || memberUuid.isBlank()) {
+//            // 공용 알람만 조회
+//            return alertMongoRepository.findByCommonAlertTrue().map(alert ->
+//                    AlertResponseDto.builder()
+//                            .key(alert.getKey())
+//                            .message(alert.getMessage())
+//                            .memberUuid(alert.getMemberUuid())
+//                            .alertType(alert.getAlertType())
+//                            .build()
+//            );
+//        } else {
+//            // 개인 알림 + 공용 알림 둘 다 merge
+//            Flux<Alert> personalAlerts = alertMongoRepository.findByMemberUuid(memberUuid);
+//            Flux<Alert> commonAlerts = alertMongoRepository.findByCommonAlertTrue();
+//        return Flux.merge(personalAlerts, commonAlerts).map(alert ->
+//                AlertResponseDto.builder()
+//                        .key(alert.getKey())
+//                        .message(alert.getMessage())
+//                        .memberUuid(alert.getMemberUuid())
+//                        .alertType(alert.getAlertType())
+//                        .build()
+//                );
+//        }
     }
 
-    @Override
-    public AlertResponseDto getAlert(AlertKafkaEvent alertKafkaEvent, AlertType alertType) {
-        AlertResponseDto responseDto = AlertResponseDto.of(
-                alertKafkaEvent.getKey(),
-                alertKafkaEvent.getMessage(),
-                alertType,
-                alertKafkaEvent.getMemberUuid(),
-                alertKafkaEvent.getCommonAlert()
-        );
-
-//        // 알람 발생 시 Sink에 이벤트 발행
-//        alertSink.tryEmitNext(responseDto);
-        // 이벤트 발행 전 sink 상태 체크 및 교체
-        Sinks.Many<AlertResponseDto> sink = getOrCreateSink();
-        Sinks.EmitResult result = sink.tryEmitNext(responseDto);
-        if (result.isFailure()) {
-            log.error("[SSE] 이벤트 발행 실패: {}", result);
-        }
-
-        return responseDto;
-    }
-
-    /**
-     * 공통 로깅/에러처리를 붙이는 메서드
-     */
-    private Flux<AlertResponseVo> decorate(Flux<AlertResponseDto> flux) {
-        return flux
-                .doOnSubscribe(sub -> log.info("[SSE] 구독 시작"))
-                .doOnCancel(() -> log.info("[SSE] 구독 취소"))
-                .doOnComplete(() -> log.info("[SSE] 구독 정상 종료"))
-                .doOnError(e -> {
-                    if (e instanceof IOException) {
-                        log.info("[SSE] 클라이언트 연결 종료 감지 (무시)");
-                    } else {
-                        log.error("[SSE] SSE 스트림 에러", e);
-                    }
-                })
-                .map(AlertResponseDto::toVo);
-    }
-
-    @Override
-    public Flux<AlertResponseVo> getAlertStream() {
-        // Sink로부터 Flux를 얻어 AlertResponseVo로 변환
-//        return alertSink.asFlux().map(AlertResponseDto::toVo);
-        return decorate(getOrCreateSink().asFlux());
-    }
-
-    @Override
-    public Flux<AlertResponseVo> getMemberAlertStream(String memberUuid) {
-//        // 특정 회원의 알림과 공통 알림 모두 제공
-//        return alertSink.asFlux()
-//                .filter(dto -> dto.getCommonAlert() ||
-//                        (dto.getMemberUuid() != null && dto.getMemberUuid().equals(memberUuid)))
-//                .map(AlertResponseDto::toVo);
-        Flux<AlertResponseDto> filtered = getOrCreateSink().asFlux()
-                .filter(dto ->
-                        dto.getCommonAlert()
-                                || (dto.getMemberUuid() != null && dto.getMemberUuid().equals(memberUuid))
-                );
-        return decorate(filtered);
-    }
-
-    @Override
-    public Flux<AlertResponseVo> getCommonAlertStream() {
-//        // 공통 알림만 제공
-//        return alertSink.asFlux()
-//                .filter(AlertResponseDto::getCommonAlert)
-//                .map(AlertResponseDto::toVo);
-        Flux<AlertResponseDto> filtered = getOrCreateSink().asFlux()
-                .filter(AlertResponseDto::getCommonAlert);
-        return decorate(filtered);
-    }
 }
+
+

--- a/src/main/java/com/pieceofcake/alert_service/alert/entity/Alert.java
+++ b/src/main/java/com/pieceofcake/alert_service/alert/entity/Alert.java
@@ -1,0 +1,43 @@
+package com.pieceofcake.alert_service.alert.entity;
+
+import com.pieceofcake.alert_service.alert.entity.enums.AlertType;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@Document(collection = "alert_message_entity")
+public class Alert {
+    @Id
+    private String id;
+    private AlertType alertType;
+    private String key;
+    private String message;
+    private String memberUuid;
+    private Boolean commonAlert = true;
+    @CreatedDate
+    private Instant createdAt;
+    @LastModifiedDate
+    private Instant updatedAt;
+
+    @Builder
+    public Alert(
+            AlertType alertType,
+            String key,
+            String message,
+            String memberUuid,
+            Boolean commonAlert
+    ) {
+        this.alertType = alertType;
+        this.key = key;
+        this.message = message;
+        this.memberUuid = memberUuid;
+        this.commonAlert = commonAlert;
+    }
+}

--- a/src/main/java/com/pieceofcake/alert_service/alert/infrastructure/AlertMongoRepository.java
+++ b/src/main/java/com/pieceofcake/alert_service/alert/infrastructure/AlertMongoRepository.java
@@ -1,0 +1,21 @@
+package com.pieceofcake.alert_service.alert.infrastructure;
+
+import com.pieceofcake.alert_service.alert.entity.Alert;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.data.mongodb.repository.Tailable;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+public interface AlertMongoRepository extends ReactiveMongoRepository<Alert, String> {
+    @Tailable
+    @Query("{ 'memberUuid' : ?0 }")
+    Flux<Alert> findByMemberUuid(String memberUuid);
+
+    @Tailable
+    @Query("{ 'commonAlert' : true }")
+    Flux<Alert> findByCommonAlertTrue();
+}
+
+

--- a/src/main/java/com/pieceofcake/alert_service/alert/presentation/AlertController.java
+++ b/src/main/java/com/pieceofcake/alert_service/alert/presentation/AlertController.java
@@ -1,17 +1,16 @@
 package com.pieceofcake.alert_service.alert.presentation;
 
 import com.pieceofcake.alert_service.alert.application.AlertService;
+import com.pieceofcake.alert_service.alert.dto.out.AlertResponseDto;
 import com.pieceofcake.alert_service.alert.vo.out.AlertResponseVo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 
@@ -22,56 +21,15 @@ public class AlertController {
 
     private final AlertService alertService;
 
-    @Operation(
-            summary = "알림 스트림 제공",
-            description = "SSE를 통해 실시간 알림 스트림을 제공합니다. \n\n" +
-                    "- memberUuid가 제공되지 않으면 공용 알림만 스트리밍하고, \n\n" +
-                    "- memberUuid가 제공되면 해당 사용자의 개인 알림과 공용 알림을 모두 스트리밍합니다.\n\n" +
-                    "- AlertType = [FUNDING_START, FUNDING_END, FUNDING_COUNT_CHANGE, PIECE_SELL_SUCCESS, PIECE_BUY_SUCCESS, PIECE_PRICE_CHANGE, VOTE_END, AUCTION_SUCCESS, AUCTION_END]"
-    )
-    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<ServerSentEvent<AlertResponseVo>> streamAlerts(
-            @Parameter(
-                    description = "회원 UUID - 제공 시 해당 회원의 개인 알림과 공용 알림 모두 수신, " +
-                            "미제공 시 공용 알림만 수신",
-                    required = false,
-                    example = "member-uuid-1234"
-            )
+    @GetMapping(value = "/stream/new", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<AlertResponseDto> getAlertByMemberUuid(
             @RequestParam(required = false) String memberUuid
     ) {
-        Flux<AlertResponseVo> alertStream;
-
-        if (memberUuid != null && !memberUuid.isEmpty()) {
-            alertStream = alertService.getMemberAlertStream(memberUuid);
-        } else {
-            alertStream = alertService.getCommonAlertStream();
-        }
-
-        // 1) 연결 직후 “init” 이벤트 한 번 보내서 프록시 버퍼 플러시
-        Flux<ServerSentEvent<AlertResponseVo>> init = Flux.just(
-                ServerSentEvent.<AlertResponseVo>builder()
-                        .comment("connected")
-                        .build()
-        );
-
-        // 2) 15초마다 빈 헬스체크(keep-alive) 주석 이벤트
-        Flux<ServerSentEvent<AlertResponseVo>> heartbeat = Flux
-                .interval(Duration.ofSeconds(15))
-                .map(tick -> ServerSentEvent.<AlertResponseVo>builder()
-                        .comment("ping")
-                        .build()
-                );
-
-        // 3) 실제 알림을 SSE로 포장
-        Flux<ServerSentEvent<AlertResponseVo>> alerts = alertStream
-                .map(alertVo -> ServerSentEvent.<AlertResponseVo>builder()
-                        .event("alert")
-                        .data(alertVo)
-                        .build()
-                );
-
-        return init.concatWith(alerts.mergeWith(heartbeat));
-//        return init.concatWith(alerts);
-
+        return alertService.getAlertByMemberUuid(memberUuid).subscribeOn(Schedulers.boundedElastic());
     }
 }
+
+
+
+
+

--- a/src/main/java/com/pieceofcake/alert_service/common/config/MongoDbConfig.java
+++ b/src/main/java/com/pieceofcake/alert_service/common/config/MongoDbConfig.java
@@ -1,0 +1,37 @@
+package com.pieceofcake.alert_service.common.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.CollectionOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
+
+@Configuration
+@EnableMongoAuditing
+@EnableReactiveMongoRepositories(basePackages = "com.pieceofcake.alert_service.alert.infrastructure")
+public class MongoDbConfig {
+
+    @Bean
+    CommandLineRunner init(MongoTemplate mongoTemplate) {
+        return args -> {
+            String collectionName = "alert_message_entity";
+
+            // 기존 컬렉션이 있으면 삭제
+            if (mongoTemplate.collectionExists(collectionName)) {
+                mongoTemplate.dropCollection(collectionName);
+                System.out.println("기존 컬렉션 삭제: " + collectionName);
+            }
+
+            // Capped Collection 생성
+            CollectionOptions options = CollectionOptions.empty()
+                    .capped()
+                    .size(10 * 1024 * 1024) // 10MB
+                    .maxDocuments(1000);    // 최대 1000개 문서
+
+            mongoTemplate.createCollection(collectionName, options);
+            System.out.println("Capped Collection 생성 완료: " + collectionName);
+        };
+    }
+}

--- a/src/main/java/com/pieceofcake/alert_service/kafka/event/AlertKafkaEvent.java
+++ b/src/main/java/com/pieceofcake/alert_service/kafka/event/AlertKafkaEvent.java
@@ -1,5 +1,6 @@
 package com.pieceofcake.alert_service.kafka.event;
 
+import com.pieceofcake.alert_service.alert.entity.Alert;
 import com.pieceofcake.alert_service.alert.entity.enums.AlertType;
 import lombok.Builder;
 import lombok.Data;
@@ -25,5 +26,15 @@ public class AlertKafkaEvent {
         this.message = message;
         this.memberUuid = memberUuid;
         this.commonAlert = commonAlert;
+    }
+
+    public Alert toEntity(AlertType alertType) {
+        return Alert.builder()
+                .key(key)
+                .message(message)
+                .memberUuid(memberUuid)
+                .alertType(alertType)
+                .commonAlert(commonAlert)
+                .build();
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,6 +17,11 @@ spring:
       max-poll-records: 100
       auto-offset-reset: earliest
 
+  data:
+    mongodb:
+      uri: mongodb+srv://${EC2_MONGOID}:${EC2_MONGOPW}@spharos.uxnx7ao.mongodb.net/piece_of_cake?retryWrites=true&w=majority
+      auto-index-creation: true
+
 eureka:
   client:
     service-url:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,11 @@ spring:
       max-poll-records: 100
       auto-offset-reset: earliest
 
+  data:
+    mongodb:
+      uri: mongodb+srv://id:password@clusterchat.kzbzyl6.mongodb.net/pieceofcake?retryWrites=true&w=majority
+      auto-index-creation: true
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 강사님 채팅 코드와 유사하게 로직 변경
  - 기존 : webFlux의 SSE 방식으로 코드 구현
    - 문제점 : 로컬에선 잘 되지만, 원격에선 무한 로딩이 발생하다 0.1초만에 모든 데이터가 들어온 뒤 연결이 끊기는 문제 발생
  - 수정 : MongoDB Change Streams를 활용한 실시간 알림 시스템으로 전환. 클라이언트가 알림 API에 연결할 때, 조건에 맞는 데이터베이스 변경사항(INSERT)이 발생하면 자동으로 해당 사용자에게 실시간 알림 전송

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
